### PR TITLE
Update condition to handle null values in UpdateEdgeAgentConfigForNode

### DIFF
--- a/app/Domain/Nodes/Actions/UpdateEdgeAgentConfigurationForNodeAction.php
+++ b/app/Domain/Nodes/Actions/UpdateEdgeAgentConfigurationForNodeAction.php
@@ -135,9 +135,9 @@ class UpdateEdgeAgentConfigurationForNodeAction
                                 'deadBand' => $v['Deadband'] ?? null,
                                 'tooltip' => $v['Tooltip'] ?? null,
                                 'docs' => $v['Documentation'] ?? null,
-                                'recordToDB' => $v['Record_To_Historian'],
+                                'recordToDB' => $v['Record_To_Historian'] ?? false,
                             ], static function ($val) {
-                                return $val;
+                                return $val !== null;
                             }
                         );
                     } elseif ($key === 'Schema_UUID') {


### PR DESCRIPTION
Changed the condition in UpdateEdgeAgentConfigurationForNodeAction to handle 'null' values. Previously, null values were being returned as is, but now they are interpreted as 'false'. This was done to ensure that false values for recordToDB are included in the config so that they can be picked up by the edge agents and interpreted for is_transient.