### PR TITLE
Upgrade PHP version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM webdevops/php-nginx:8.1-alpine
+FROM webdevops/php-nginx:8.2-alpine
 
 # System dependencies
 RUN apk add --no-cache autoconf krb5-libs krb5-dev oniguruma-dev postgresql-dev libxml2-dev nodejs yarn gcc make g++ zlib-dev


### PR DESCRIPTION
Updated the utilized PHP version from 8.1 to 8.2 in the Dockerfile. This change is to leverage the latest features and improvements PHP 8.2 provides, along with ensuring compatibility with our current codebase.