### PR TITLE
Add Open Protocol to DeviceConnectionForm

### DIFF
--- a/resources/js/components/General/DeviceConnectionForm.vue
+++ b/resources/js/components/General/DeviceConnectionForm.vue
@@ -351,6 +351,7 @@ export default {
               'S7',
               'UDP',
               'MTConnect',
+              'Open Protocol'
             ],
           },
           'UDPConnDetails': {
@@ -513,6 +514,41 @@ export default {
                 title: 'Keep Alive Interval (sec)',
                 default: 60,
               },
+            },
+          },
+          'OpenProtocolConnDetails': {
+            type: 'object',
+            title: 'Open Protocol Details',
+            properties: {
+              host: {
+                type: 'string',
+                showIf: () => {
+                  return this.model.connType === 'Open Protocol' || false;
+                },
+                validations: {
+                  requiredIf: requiredIf(() => {
+                    return this.model.connType === 'Open Protocol' || false;
+                  }),
+                  minLength: minLength(3),
+                },
+                description: 'The hostname of the controller to connect to.',
+                title: 'Hostname/IP',
+              },
+              port: {
+                type: 'number',
+                description: 'The port number to connect to the controller on.',
+                title: 'Port',
+                showIf: () => {
+                  return this.model.connType === 'Open Protocol' || false;
+                },
+                validations: {
+                  requiredIf: requiredIf(() => {
+                    return this.model.connType === 'Open Protocol' || false;
+                  }),
+                  numeric,
+                },
+                default: 4545,
+              }
             },
           },
           'OPCUAConnDetails': {


### PR DESCRIPTION
New connection type 'Open Protocol' has been added to DeviceConnectionForm in DeviceConnectionForm.vue. This additional type comes with necessary connection details like hostname and port number, including their validations and default values. This change was necessary to connect and communicate with machines equipped with an 'Open Protocol' interface.