### PR TITLE
Add OpenProtocol connection details to DeviceConnectionForm

### DIFF
--- a/resources/js/components/General/DeviceConnectionForm.vue
+++ b/resources/js/components/General/DeviceConnectionForm.vue
@@ -299,6 +299,10 @@ export default {
           username: null,
           password: null,
         },
+        OpenProtocolConnDetails: {
+          host: null,
+          port: '4545',
+        },
         RESTConnDetails: {
           baseURL: '',
           authMethod: 'None',


### PR DESCRIPTION
OpenProtocol connection details have been added to the DeviceConnectionForm component to allow connection to devices that use the OpenProtocol communication protocol. Default port set to '4545'.