### PR TITLE
Update regex in EdgeAgentEntry validation

### DIFF
--- a/resources/js/components/EdgeAgents/EdgeAgentEntry.vue
+++ b/resources/js/components/EdgeAgents/EdgeAgentEntry.vue
@@ -128,7 +128,7 @@ export default {
   validations() {
     return {
       newVersion: {
-        regex: helpers.withMessage('Must be semver', helpers.regex(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/)),
+        regex: helpers.withMessage('Must be semver', helpers.regex(/^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/)),
       }
     };
   },


### PR DESCRIPTION
The regular expression for validating new version strings in EdgeAgentEntry component was updated. The change was made to permit version strings that start with a 'v' character, aligning with conventional semantic versioning formats.