### PR TITLE
Ensure origin maps are using the schema_uuid from the actual file

### DIFF
--- a/app/Domain/Devices/Resources/DeviceDetailResource.php
+++ b/app/Domain/Devices/Resources/DeviceDetailResource.php
@@ -25,7 +25,6 @@ class DeviceDetailResource extends JsonResource
             'updated_at' => $this['updated_at'],
             'id' => $this['id'],
             'instance_uuid' => $this['instance_uuid'] ?? null,
-            'schema_uuid' => $this['schema_uuid'] ?? null,
             'node_id' => $this['node_id'],
             'device_id' => $this['device_id'],
             'device_connection_id' => $this['device_connection_id'],

--- a/database/migrations/2023_10_05_095650_update_origin_map_schema_uuids_with_real_schema_uuids_from_config.php
+++ b/database/migrations/2023_10_05_095650_update_origin_map_schema_uuids_with_real_schema_uuids_from_config.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ *  Factory+ / AMRC Connectivity Stack (ACS) Manager component
+ *  Copyright 2023 AMRC
+ */
+
+use App\Domain\OriginMaps\Models\OriginMap;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        foreach (OriginMap::all() as $originMap) {
+            $schemaUUID = json_decode(Storage::disk('device-configurations')->get($originMap->file))?->Schema_UUID;
+            if ($schemaUUID) {
+                $originMap->schema_uuid = $schemaUUID;
+                $originMap->save();
+            }
+        }
+        
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+};


### PR DESCRIPTION
Previously they were based on the `schema_uuid` of the device, which was a deprecated field.