### PR TITLE
Add exception handling in device and node deletion

### DIFF
--- a/app/Domain/Devices/Actions/DeleteDeviceAction.php
+++ b/app/Domain/Devices/Actions/DeleteDeviceAction.php
@@ -10,6 +10,7 @@ use App\Domain\Devices\Models\Device;
 use App\Domain\Nodes\Actions\UpdateEdgeAgentConfigurationForNodeAction;
 use App\Exceptions\ActionFailException;
 use App\Exceptions\ActionForbiddenException;
+use Illuminate\Support\Facades\Log;
 use function func_get_args;
 
 class DeleteDeviceAction
@@ -36,7 +37,11 @@ class DeleteDeviceAction
 
         $device->originMaps()->delete();
         $device->delete();
-        (new UpdateEdgeAgentConfigurationForNodeAction())->execute($device->node);
+        try {
+            (new UpdateEdgeAgentConfigurationForNodeAction())->execute($device->node);
+        } catch (ActionFailException $e) {
+            Log::warning('Failed to update edge agent configuration for node ' . $device->node->node_id . ' after deleting device ' . $device->device_id);
+        }
 
         return action_success();
     }

--- a/app/Domain/Nodes/Actions/DeleteNodeAction.php
+++ b/app/Domain/Nodes/Actions/DeleteNodeAction.php
@@ -57,34 +57,29 @@ class DeleteNodeAction
         // Get the K8s cluster
         if (in_array(config('app.env'), ['local', 'testing']) && env('K8S_DEPLOY_WHEN_LOCAL', false)) {
             ray('Using local K8s config file');
-            $cluster = KubernetesCluster::fromKubeConfigYamlFile(
-                env('LOCAL_KUBECONFIG'),
-                'default'
-            );
+            $cluster = KubernetesCluster::fromKubeConfigYamlFile(env('LOCAL_KUBECONFIG'), 'default');
         } else {
             $cluster = KubernetesCluster::inClusterConfiguration();
         }
 
-        $k8sSafeName = substr(
-            str_replace('_', '-', (new BuildKerberosCRDNameAction())->execute($node->group, $nodeHostname, $node->node_id)['data']),
-            0,
-            60
-        );
+        $k8sSafeName = substr(str_replace('_', '-', (new BuildKerberosCRDNameAction())->execute($node->group, $nodeHostname, $node->node_id)['data']), 0, 60);
         $namespace = $node->group->cluster->namespace;
         $nodeUuid = $node->uuid;
 
         // Delete the KerberosKey
-        KerberosKey::register('kk');
-        $kerberosKey = $cluster->kk()->whereNamespace($namespace)->getByName($k8sSafeName);
-        if ($kerberosKey) {
-            $kerberosKey->delete();
+        try {
+            KerberosKey::register('kk');
+            $cluster->kk()->whereNamespace($namespace)->getByName($k8sSafeName)->delete();
+        } catch (\Exception $e) {
+            Log::warning('Failed to delete KerberosKey for node ' . $node->node_id . ' (' . $node->uuid . ')');
         }
 
         // Remove the Edge Agent
-        $deploymentName = (!$isCellGateway ? '' : 'soft-') . 'edge-agent-' . $nodeUuid;
-        $deployment = $cluster->deployment()->whereNamespace($namespace)->getByName($deploymentName);
-        if ($deployment) {
-            $deployment->delete();
+        try {
+            $deploymentName = (!$isCellGateway ? '' : 'soft-') . 'edge-agent-' . $nodeUuid;
+            $cluster->deployment()->whereNamespace($namespace)->getByName($deploymentName)->delete();
+        } catch (\Exception $e) {
+            Log::warning('Failed to delete deployment for node ' . $node->node_id . ' (' . $node->uuid . ')');
         }
 
         //-----------------|
@@ -96,24 +91,19 @@ class DeleteNodeAction
         // UUIDs are not reused.
 
         // Remove the entry in the Auth service that maps the Kerberos principal to the node UUID
-        (new MakeConsumptionFrameworkRequest)->execute(
-            type: 'delete',
-            service: 'auth',
-            url: config('manager.auth_service_url') . '/authz/principal/'.$nodeUuid,
-        );
+        try {
+
+            (new MakeConsumptionFrameworkRequest)->execute(type: 'delete', service: 'auth', url: config('manager.auth_service_url') . '/authz/principal/' . $nodeUuid,);
+        } catch (\Exception $e) {
+            Log::error('Failed to delete principal for node ' . $node->node_id . ' (' . $node->uuid . ')');
+        }
 
         // Remove the ACL entry that allows the new node to participate as an Edge Node (87e4a5b7-9a89-4796-a216-39666a47b9d2)
-        (new MakeConsumptionFrameworkRequest)->execute(
-            type: 'post',
-            service: 'auth',
-            url: config('manager.auth_service_url') . '/authz/ace',
-            payload: [
-                'action' => 'delete',
-                'principal' => $nodeUuid,
-                'permission' => '87e4a5b7-9a89-4796-a216-39666a47b9d2',
-                'target' => $nodeUuid,
-            ]
-        );
+        try {
+            (new MakeConsumptionFrameworkRequest)->execute(type: 'post', service: 'auth', url: config('manager.auth_service_url') . '/authz/ace', payload: ['action' => 'delete', 'principal' => $nodeUuid, 'permission' => '87e4a5b7-9a89-4796-a216-39666a47b9d2', 'target' => $nodeUuid,]);
+        } catch (\Exception $e) {
+            Log::error('Failed to delete ACL entry for node ' . $node->node_id . ' (' . $node->uuid . ')');
+        }
 
         // Delete the node and all connections
         $node->deviceConnections()->delete();


### PR DESCRIPTION
Added exception handling blocks to ensure any failures in particular steps of deleting a node or device doesn't stop the full process. Errors that occur during the update of EdgeAgentConfigurationForNode, deletion of KerberosKey, deletion of a deployment, or deletion of principal from AuthService and ACL entry are now caught and a relevant message is logged, instead of the system halting the process. This will allow for smoother execution and improve debuggability.